### PR TITLE
Alternative varma method

### DIFF
--- a/models/DSGE.m
+++ b/models/DSGE.m
@@ -201,12 +201,22 @@ classdef DSGE < handle & Model
             q = kappa + 1;
 
             % Finding VARMA Coefficients
-            Theta = FPlus(:, 1:n);
-            ThetaPlus = pinv(Theta);  % Checked rank conditions above.
+            [Phi0, As, Psis] = DSGE.recoverVarmaMorris_(p, q, FPlus, A, B, C, D, S);
+        end
 
-            G = cell(1, kappa+1);
-            for col=1:(kappa+1)
-                Gcol = zeros(n*(kappa+1), n);
+        function [Phi0, As, Psis] = recoverVarmaMorris_(p, q, FPlus, A, B, C, D, S)
+            % Fplus as defined in Morris and in dynareToVarma_
+            % A, B, C, D define DSGE state space
+            % S diagonal matrix of shock standard deviations
+
+            n = size(C, 1);
+            m = size(A, 1);
+            Theta = FPlus(:, 1:n);
+            ThetaPlus = pinv(Theta);  % Assume rank condition has been checked
+
+            G = cell(1, p);
+            for col=1:(p)
+                Gcol = zeros(n*(p), n);
                 for row=1:(col-1)
                     rowStart = (row-1)*n+1;
                     rowEnd = row*n;
@@ -218,24 +228,24 @@ classdef DSGE < handle & Model
                 G{col} = Gcol;
             end
 
-            As = cell(1, kappa+1);
+            As = cell(1, p);
             Phi0 = ThetaPlus * FPlus * G{1};
             A0 = inv(Phi0);
             Phi0 = Phi0 * S;  % re-normalising shock variances
-            for k=1:kappa
+            for k=1:(p-1)
                 colStart = (k-1)*n + 1;
                 colEnd = k*n;
                 As{k} = ThetaPlus * (A*FPlus(:, colStart:colEnd) - FPlus(:, (colStart+n):(colEnd+n)));
             end
-            colStart = (kappa+1-1)*n + 1;
-            colEnd = (kappa+1)*n;
+            colStart = (p-1)*n + 1;
+            colEnd = (p)*n;
             As{end} = ThetaPlus * A * FPlus(:, colStart:colEnd);
 
-            Psis = cell(1, kappa+1);
-            for k=1:kappa
+            Psis = cell(1, p);
+            for k=1:(p-1)
                 Psis{k} = ThetaPlus * (FPlus * G{k+1} - A * FPlus * G{k}) * A0;
             end
-            Psis{end} = ThetaPlus * (B - A * FPlus * G{kappa+1}) * A0;
+            Psis{end} = ThetaPlus * (B - A * FPlus * G{p}) * A0;
         end
 
         function [A, B, C, D] = getABCD_(M_, oo_, options_)

--- a/models/DSGE.m
+++ b/models/DSGE.m
@@ -455,6 +455,52 @@ classdef DSGE < handle & Model
             end
         end
 
+        function irfs = stateSpaceIrfs_(A, B, C, D, S, horizon)
+            % `stateSpaceIrfs_` Compute structural IRFs from a DSGE state-space system.
+            %
+            %   `irfs = stateSpaceIrfs_(A, B, C, D, S, horizon)` computes
+            %   impulse response functions from the state-space representation
+            %   returned by `getABCD_`:
+            %   $$
+            %   \begin{split}
+            %   x_t &= Ax_{t-1} + B\varepsilon_t \\
+            %   y_t &= Cx_{t-1} + D\varepsilon_t
+            %   \end{split}
+            %   $$
+            %   where the shocks are scaled by `S` so that the responses match
+            %   Dynare's convention of one-standard-deviation structural shocks.
+            %
+            %   ## Arguments
+            %   - `A` (matrix): State transition matrix.
+            %   - `B` (matrix): Shock loading matrix in the state equation.
+            %   - `C` (matrix): Observation matrix.
+            %   - `D` (matrix): Contemporaneous shock impact matrix.
+            %   - `S` (matrix): Diagonal matrix of shock standard deviations.
+            %   - `horizon` (integer): Maximum IRF horizon. `horizon=0`
+            %     returns only the contemporaneous impact.
+            %
+            %   ## Returns
+            %   - `irfs` (3D array): Structural IRFs of size
+            %     `(n_observables, n_shocks, horizon+1)`.
+            %
+            %   ## Notes
+            %   - Horizon 0 equals `D*S`.
+            %   - For `h >= 1`, the response is `C*A^(h-1)*B*S`.
+            %
+            %   See also `getABCD_`, `varmaIrfs_`
+
+            nObs = size(C, 1);
+            nShocks = size(D, 2);
+            irfs = zeros(nObs, nShocks, horizon+1);
+            irfs(:, :, 1) = D * S;
+
+            stateResponse = B * S;
+            for h=1:horizon
+                irfs(:, :, h+1) = C * stateResponse;
+                stateResponse = A * stateResponse;
+            end
+        end
+
     end
 
     methods
@@ -580,7 +626,8 @@ classdef DSGE < handle & Model
             % `IRF` Compute impulse response functions for DSGE model.
             %
             %   `irfObj = IRF(obj, maxHorizon)` computes IRFs of the DSGE
-            %   model up to horizon `maxHorizon`.
+            %   model up to horizon `maxHorizon`. Uses the VARMA representation
+            %   of the DSGE.
             %
             %   ## Arguments
             %   - `obj` (DSGE): DSGE model object.
@@ -595,6 +642,34 @@ classdef DSGE < handle & Model
             %   See also `coeffs`, `dynareToVarma_`, `varmaIrfs_`
             [Phi0, As, Psis] = obj.coeffs();
             irfs = DSGE.varmaIrfs_(Phi0, As, Psis, maxHorizon);
+            varnames = obj.getVariableNames();
+            irfObj = IRFContainer(irfs, varnames, obj);
+        end
+
+        function irfObj = IRFStateSpace(obj, maxHorizon)
+            % `IRFStateSpace` Compute impulse response functions from the DSGE state-space form.
+            %
+            %   `irfObj = IRFStateSpace(obj, maxHorizon)` computes IRFs of the
+            %   DSGE model directly from the state-space representation
+            %   obtained via `getABCD_`.
+            %
+            %   ## Arguments
+            %   - `obj` (DSGE): DSGE model object.
+            %   - `maxHorizon` (integer): Maximum forecast horizon.
+            %
+            %   ## Returns
+            %   - `irfObj` (IRFContainer): Container with computed IRFs.
+            %
+            %   ## Notes
+            %   - Structural shocks are scaled by their standard deviations so
+            %     that the returned IRFs match Dynare output.
+            %   - The resulting IRFs are equivalent to those obtained from the
+            %     VARMA representation used by `IRF`.
+            %
+            %   See also `IRF`, `getABCD_`, `varmaIrfs_`
+            [A, B, C, D] = DSGE.getABCD_(obj.M_, obj.oo_, obj.options_);
+            S = sqrt(DSGE.getShockVariances_(obj.M_));
+            irfs = DSGE.stateSpaceIrfs_(A, B, C, D, S, maxHorizon);
             varnames = obj.getVariableNames();
             irfObj = IRFContainer(irfs, varnames, obj);
         end

--- a/models/DSGE.m
+++ b/models/DSGE.m
@@ -205,9 +205,45 @@ classdef DSGE < handle & Model
         end
 
         function [Phi0, As, Psis] = recoverVarmaMorris_(p, q, FPlus, A, B, C, D, S)
-            % Fplus as defined in Morris and in dynareToVarma_
-            % A, B, C, D define DSGE state space
-            % S diagonal matrix of shock standard deviations
+            % `recoverVarmaMorris_` Recover VARMA coefficients from Morris's construction.
+            %
+            %   `[Phi0, As, Psis] = recoverVarmaMorris_(p, q, FPlus, A, B, C, D, S)`
+            %   computes the VARMA coefficient matrices once `dynareToVarma_`
+            %   has established the rank conditions and constructed the matrix
+            %   `FPlus` used in the general case of Morris (2016).
+            %
+            %   ## Arguments
+            %   - `p` (integer): Autoregressive order determined in `dynareToVarma_`.
+            %   - `q` (integer): Moving-average order determined in
+            %     `dynareToVarma_`.
+            %   - `FPlus` (matrix): Pseudoinverse of the stacked observability
+            %     matrix `F` constructed in `dynareToVarma_`.
+            %   - `A` (matrix): State transition matrix from the DSGE
+            %     state-space representation.
+            %   - `B` (matrix): Shock loading matrix from the DSGE state-space
+            %     representation.
+            %   - `C` (matrix): Observation matrix from the DSGE state-space
+            %     representation.
+            %   - `D` (matrix): Contemporaneous shock impact matrix from the
+            %     DSGE state-space representation.
+            %   - `S` (matrix): Diagonal matrix of shock standard deviations
+            %     used to re-scale shocks to their original variance.
+            %
+            %   ## Returns
+            %   - `Phi0` (matrix): Contemporaneous impact matrix in the
+            %     recovered VARMA representation.
+            %   - `As` (cell array): AR coefficient matrices `{A_1, ..., A_p}`.
+            %   - `Psis` (cell array): MA coefficient matrices
+            %     `{Psi_1, ..., Psi_q}`.
+            %
+            %   ## Notes
+            %   - This helper is used by `dynareToVarma_` only in the general
+            %     case where the observation matrix `C` is not square and
+            %     invertible.
+            %   - The function assumes the relevant rank conditions for `F`
+            %     and `FPlus(:, 1:n)` have already been checked.
+            %
+            %   See also `dynareToVarma_`, `getABCD_`
 
             n = size(C, 1);
             m = size(A, 1);

--- a/models/DSGE.m
+++ b/models/DSGE.m
@@ -91,10 +91,10 @@ classdef DSGE < handle & Model
           v = v(:);
         end
 
-        function [Phi0, As, Psis, p, q] = dynareToVarma_(M_, oo_, options_, maxKappa)
+        function [Phi0, As, Psis, p, q] = dynareToVarma_(M_, oo_, options_, pMax)
             % `dynareToVarma_` Transform a DSGE model into VARMA representation.
             %
-            %   `[Phi0, As, Psis, p, q] = dynareToVarma_(M_, oo_, options_, maxKappa)`
+            %   `[Phi0, As, Psis, p, q] = dynareToVarma_(M_, oo_, options_, pMax)`
             %   converts a linearized DSGE model estimated using Dynare into a
             %   VARMA form, following the method of Morris (2016).
             %
@@ -102,8 +102,7 @@ classdef DSGE < handle & Model
             %   - `M_` (struct): Model structure returned by Dynare.
             %   - `oo_` (struct): Output structure returned by Dynare.
             %   - `options_` (struct): Options structure returned by Dynare.
-            %   - `maxKappa` (integer, optional): Tuning parameter related to
-            %     maximum AR order via `maxArOrder = maxKappa + 1`. Defaults to 20.
+            %   - `pMax` (integer, optional): Maximum AR order to try. 
             %
             %   ## Returns
             %   - `Phi0` (matrix): Impact matrix linking shocks to reduced-form errors.
@@ -136,23 +135,27 @@ classdef DSGE < handle & Model
                 error("dynareToVarma: No observed variables were defined in the mod file.")
             end
 
-            % Default choice for maximum VAR order following notation in Morris 2016.
+            % Default choice for maximum VAR order
             if nargin==3
-                maxKappa = 20;
+                pMax = 20;
             end
 
             [A, B, C, D] = DSGE.getABCD_(M_, oo_, options_);
             % Note that this state-space form still allows for shocks that have
             % non-unity variance. Since we work with shocks that have unity
-            % variance, we need to renormalise the Phi0 matrices below using the
-            % sqrt of the shock covariance matrix
+            % variance, we change below the shock related matrices B and D. 
             S = sqrt(DSGE.getShockVariances_(M_));
+            % B = B*S;
+            % D = D*S;
 
             % Basic assumption is that D is invertible.
-            condTolerance = 1e-20;
-            if rcond(D) < condTolerance
-                error("Matrix D must not be singular.")
+            if size(D, 1) ~= size(D, 2)
+                error("Matrix D must be square")
             end
+            if rank(D) ~= size(D, 1)
+                error("Matrix D must not be singular")
+            end
+            Phi0 = D*S;
 
             n = size(C, 1);
             m = size(A, 1);
@@ -160,128 +163,69 @@ classdef DSGE < handle & Model
             %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
             % Case I: C is invertible. In that case, p=q=1;
             %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-            if n==m && rcond(C) > condTolerance
+            if n==m && rank(C) == n
                 p = 1;
                 q = 1;
 
                 % Finding AR, MA matrices
                 CInv = inv(C);
                 DInv = inv(D);
-                Phi0 = D;
-                Phi0 = Phi0 * S;  % re-normlising shock variances
                 As = {C*A*CInv};
                 Psis = {C*(B - A*CInv*D)*DInv};
                 return;
             end
 
             %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-            % Case II: Follow the general proposition of Morris 2016
-            % but adjusted for our notation.
+            % Case II: Follow the general proposition of Morris 2016.
+            % Algorithm was slightly adjusted for better implementation.  
             %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-            kappa = 0;
-            F = [C];
-            while kappa < maxKappa
-                kappa = kappa + 1;
-                F = [C*A^kappa; F];
-                if rank(F) == size(F, 2)
-                    FPlus = pinv(F);  % Checked rank condition above.
-                    if rank(FPlus(:, 1:n)) == n
-                        break  % Both rank conditions are satisfied.
-                    end
+            % Finding smallest M for which F matrix is full column rank. 
+            % If F is full column rank for M, then VARMA has AR order M+1. 
+            % Thus, our search cannot exceed pMax-1.
+            B = B * inv(D);
+            F = zeros(0, n);
+            p = missing;
+            for M = 0:(pMax-1)
+                F = [C*A^M; F];
+                if rank(F) == m
+                    p = M + 1;
+                    break;
                 end
             end
-            if rank(F) ~= size(F, 2)
-                error("dynareToVarma: Rank condition for F is not satisfied. Could not find VARMA representation of DSGE.")
+
+            if ismissing(p)
+                error("Could not find VARMA with p <= %i", pMax)
             end
-            FPlus = pinv(F);  % Checked rank condition above
-            if rank(FPlus(:, 1:n)) ~= n
-                error("dynareToVarma: Rank condition for FPlus is not satisfied. Could not find VARMA representation of DSGE.")
+            q = p;
+
+            FPlus = pinv(F);
+
+            % Recovering AR coefficients
+            Bcoeffs = F * A * FPlus;
+            Bcoeffs = Bcoeffs(1:n, :);
+            As = VAR.coeffsToCellArray_(Bcoeffs);
+
+            % Constructing G matrix to recover MA coefficients
+            GFirstRow = eye(n);
+            for M = 0:(q-2)
+                tmp = C * A^M * B;
+                GFirstRow = [GFirstRow tmp];
             end
-            p = kappa + 1;
-            q = kappa + 1;
-
-            % Finding VARMA Coefficients
-            [Phi0, As, Psis] = DSGE.recoverVarmaMorris_(p, q, FPlus, A, B, C, D, S);
-        end
-
-        function [Phi0, As, Psis] = recoverVarmaMorris_(p, q, FPlus, A, B, C, D, S)
-            % `recoverVarmaMorris_` Recover VARMA coefficients from Morris's construction.
-            %
-            %   `[Phi0, As, Psis] = recoverVarmaMorris_(p, q, FPlus, A, B, C, D, S)`
-            %   computes the VARMA coefficient matrices once `dynareToVarma_`
-            %   has established the rank conditions and constructed the matrix
-            %   `FPlus` used in the general case of Morris (2016).
-            %
-            %   ## Arguments
-            %   - `p` (integer): Autoregressive order determined in `dynareToVarma_`.
-            %   - `q` (integer): Moving-average order determined in
-            %     `dynareToVarma_`.
-            %   - `FPlus` (matrix): Pseudoinverse of the stacked observability
-            %     matrix `F` constructed in `dynareToVarma_`.
-            %   - `A` (matrix): State transition matrix from the DSGE
-            %     state-space representation.
-            %   - `B` (matrix): Shock loading matrix from the DSGE state-space
-            %     representation.
-            %   - `C` (matrix): Observation matrix from the DSGE state-space
-            %     representation.
-            %   - `D` (matrix): Contemporaneous shock impact matrix from the
-            %     DSGE state-space representation.
-            %   - `S` (matrix): Diagonal matrix of shock standard deviations
-            %     used to re-scale shocks to their original variance.
-            %
-            %   ## Returns
-            %   - `Phi0` (matrix): Contemporaneous impact matrix in the
-            %     recovered VARMA representation.
-            %   - `As` (cell array): AR coefficient matrices `{A_1, ..., A_p}`.
-            %   - `Psis` (cell array): MA coefficient matrices
-            %     `{Psi_1, ..., Psi_q}`.
-            %
-            %   ## Notes
-            %   - This helper is used by `dynareToVarma_` only in the general
-            %     case where the observation matrix `C` is not square and
-            %     invertible.
-            %   - The function assumes the relevant rank conditions for `F`
-            %     and `FPlus(:, 1:n)` have already been checked.
-            %
-            %   See also `dynareToVarma_`, `getABCD_`
-
-            n = size(C, 1);
-            m = size(A, 1);
-            Theta = FPlus(:, 1:n);
-            ThetaPlus = pinv(Theta);  % Assume rank condition has been checked
-
-            G = cell(1, p);
-            for col=1:(p)
-                Gcol = zeros(n*(p), n);
-                for row=1:(col-1)
-                    rowStart = (row-1)*n+1;
-                    rowEnd = row*n;
-                    Gcol(rowStart:rowEnd, :) = C*A^(col-row-1)*B;
-                end
-                rowStart = (col-1)*n+1;
-                rowEnd = col*n;
-                Gcol(rowStart:rowEnd, :) = D;
-                G{col} = Gcol;
+            G = zeros(n * q, n * q);
+            for i = 1:q
+                skip = (i - 1) * n;
+                r = (i - 1) * n + 1;
+                G(r:(r + n - 1), (skip + 1):end) = GFirstRow(:, 1:(end-skip));
             end
 
-            As = cell(1, p);
-            Phi0 = ThetaPlus * FPlus * G{1};
-            A0 = inv(Phi0);
-            Phi0 = Phi0 * S;  % re-normalising shock variances
-            for k=1:(p-1)
-                colStart = (k-1)*n + 1;
-                colEnd = k*n;
-                As{k} = ThetaPlus * (A*FPlus(:, colStart:colEnd) - FPlus(:, (colStart+n):(colEnd+n)));
-            end
-            colStart = (p-1)*n + 1;
-            colEnd = (p)*n;
-            As{end} = ThetaPlus * A * FPlus(:, colStart:colEnd);
-
-            Psis = cell(1, p);
-            for k=1:(p-1)
-                Psis{k} = ThetaPlus * (FPlus * G{k+1} - A * FPlus * G{k}) * A0;
-            end
-            Psis{end} = ThetaPlus * (B - A * FPlus * G{p}) * A0;
+            % Recovering MA coefficients
+            Psicoeffs = zeros(n, n * q);
+            Psicoeffs(:, 1:(end - n)) = G(1:n, (n + 1):end);
+            FAFPlusG = F * A * FPlus * G;
+            Psicoeffs = Psicoeffs - FAFPlusG(1:n, :);
+            FB = F * B;
+            Psicoeffs(:, (end - n + 1):end) = Psicoeffs(:, (end - n + 1):end) + FB(1:n, :);
+            Psis = VAR.coeffsToCellArray_(Psicoeffs);
         end
 
         function [A, B, C, D] = getABCD_(M_, oo_, options_)

--- a/models/VAR.m
+++ b/models/VAR.m
@@ -168,6 +168,35 @@ classdef VAR < handle & Model
             end
         end
 
+        function B = cellArrayToCoeffs_(BCellArray)
+            % `cellArrayToCoeffs_` Transform a cell array of coefficient matrices
+            % into a stacked coefficient matrix. 
+            %
+            %   `B = cellArrayToCoeffs_(BCellArray)` converts the cell array 
+            %   `{B1, B2, ..., Bp}` into the stacked coefficient matrix 
+            %   `[B1 B2 ... Bp]`. 
+            %
+            %   ## Arguments
+            %   - `BCellArray` (cell array): Cell array containing the coefficient
+            %     matrices.
+            %   
+            %   ## Returns
+            %   - `B` (matrix): Stacked coefficient matrix excluding
+            %     deterministic components (i.e., the matrix does not include
+            %     the constant or trans coefficients `C`). Size is `(k, k*p)`
+            %     where `k` is the number of variables and `p` is the lag order.
+            %
+            %   See also `DSGE.coeffsToCellArray_`.
+            p = size(BCellArray, 2);
+            k = size(BCellArray{1, 1}, 1);
+            B = zeros(k, k*p);
+            for i = 1:p
+                c = (i - 1) * k + 1;
+                B(:, c:(c + k - 1)) = BCellArray{1, i};
+            end
+        end
+
+
         function Y = simulate(errorsOrT, B, varargin)
             % `simulate` Simulate a VAR process given errors or time periods.
             %

--- a/tests/modelDSGETest.m
+++ b/tests/modelDSGETest.m
@@ -70,6 +70,19 @@ function testDSGEVarmaSW2007(testCase)
     assert(testew < tol);
 end
 
+function testDSGEStateSpaceSW2007(testCase)
+    load ./tests/SW2007/SW2007/Output/SW2007_results.mat
+    model = DSGE(M_, options_, oo_);
+    maxHorizon = 19;
+    irfsStateSpace = model.IRFStateSpace(maxHorizon).irfs;
+    irfsVarma = model.IRF(maxHorizon).irfs;
+    irfsDynare = getDynareObservedIrfs(model, oo_, maxHorizon);
+
+    tol = 1e-9;
+    assert(max(vec(abs(irfsStateSpace - irfsVarma))) < tol);
+    assert(max(vec(abs(irfsStateSpace - irfsDynare))) < tol);
+end
+
 function testDSGEVarmaGali2015(testCase)
     %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
     % SETTING UP THE TEST
@@ -114,6 +127,19 @@ function testDSGEVarmaGali2015(testCase)
     assert(testeps_a < tol);
 end
 
+function testDSGEStateSpaceGali2015(testCase)
+    load ./tests/Gali2015/Gali2015Chapter3/Output/Gali2015Chapter3_results.mat
+    model = DSGE(M_, options_, oo_);
+    maxHorizon = 19;
+    irfsStateSpace = model.IRFStateSpace(maxHorizon).irfs;
+    irfsVarma = model.IRF(maxHorizon).irfs;
+    irfsDynare = getDynareObservedIrfs(model, oo_, maxHorizon);
+
+    tol = 1e-9;
+    assert(max(vec(abs(irfsStateSpace - irfsVarma))) < tol);
+    assert(max(vec(abs(irfsStateSpace - irfsDynare))) < tol);
+end
+
 function testDSGETransmission(testCase)
     % THESE TESTS ARE ONLY IMPLEMENTATION TESTS. THE UNDERLYING FUNCTIONS
     % HAVE BEEN TESTED ELSEWHERE.
@@ -136,4 +162,20 @@ function testDSGETransmission(testCase)
     shock = 'em';
     effects = model.transmission(shock, q, order, maxHorizon);
     % effects(4, :, :)
+end
+
+function irfsDynare = getDynareObservedIrfs(model, oo_, maxHorizon)
+    varnames = model.getVariableNames();
+    shocknames = model.getShockNames();
+    nVars = length(varnames);
+    nShocks = length(shocknames);
+    irfsDynare = zeros(nVars, nShocks, maxHorizon+1);
+
+    for iVar = 1:nVars
+        for iShock = 1:nShocks
+            fieldName = sprintf('%s_%s', char(varnames(iVar)), char(shocknames(iShock)));
+            series = oo_.irfs.(fieldName);
+            irfsDynare(iVar, iShock, :) = reshape(series(1:(maxHorizon+1)), 1, 1, []);
+        end
+    end
 end


### PR DESCRIPTION
Implemented an alternative method to convert the state-space representation to a VARMA. The idea is still based on Morries, but the computation is slightly different. 

Motivation: The current implementation failed to produce a stable VARMA for the Gali model with capital and investment adjustment costs. This hinted at numerical issues in the implementation. 

